### PR TITLE
Removing unsupported chars in script and email template.

### DIFF
--- a/message.txt
+++ b/message.txt
@@ -1,8 +1,8 @@
 Dear Representative (Senator) {},
 
-Legislative Bill HR 1044, “Fairness for High-Skilled Immigrants Act of 2019” is one of the most controversial, yet potentially damaging legislation in Congress. This legislation favors only one country, encourages H1b abuses, and allows it to completely co-opt the entire Employment Based Green Card program .
+Legislative Bill HR 1044, "Fairness for High-Skilled Immigrants Act of 2019" is one of the most controversial, yet potentially damaging legislation in Congress. This legislation favors only one country, encourages H1b abuses, and allows it to completely co-opt the entire Employment Based Green Card program .
 
-A “YES VOTE” or co-sponsoring HR1044, “Fairness for High-Skilled Immigrants Act of 2019”, would effectively wipe out ethnic diversity in the skilled legal immigration system and be detrimental to the vital interests of the USA.
+A "YES VOTE" or co-sponsoring HR1044, "Fairness for High-Skilled Immigrants Act of 2019", would effectively wipe out ethnic diversity in the skilled legal immigration system and be detrimental to the vital interests of the USA.
 
 While sympathizing the long backlog that immigrants origin in India are currently suffering, I believe HR1044 will only make the situation worse because:
 
@@ -26,7 +26,7 @@ Furthermore, I firmly believe that the bill will serve its purpose ONLY AFTER en
 
 Finally, I agree that we should address the backlog problem that Indian immigrants face, yet a special deal to help them who are already in the queue is better than an institutionalized pathway benefiting only tech giants and outsourcing companies at the cost of everyone else in the long run. An amnesty bill could help clear the backlog, but we should not encourage more outsourcing and H1b abuse just to give green card to the people who are already in the queue.
 
-Above are my arguments against the HR1044/S386 bill. I urge you to vote “NO” to the bill until it addresses all the above issues. Our immigration system should not be abused and we should act to protect the diversity of our immigration community.
+Above are my arguments against the HR1044/S386 bill. I urge you to vote "NO" to the bill until it addresses all the above issues. Our immigration system should not be abused and we should act to protect the diversity of our immigration community.
 
 Thank you and looking forward to your reply!
 

--- a/sendEmail.py
+++ b/sendEmail.py
@@ -6,11 +6,11 @@ from time import sleep
 file=open("message.txt", "r")
 message_body = file.read()
 
-email = input("Your email: ")　#邮箱账户
-password = input("You password: ") #邮箱密码
-user_name = input("What is your name(first_name + last_name): ") #邮件结尾最后的名字
+email = input("Your email: ")
+password = input("You password: ")
+user_name = input("What is your name(first_name + last_name): ")
 
-smtpserver = smtplib.SMTP("smtp.gmail.com", 587)　# Gmail的服务器登录
+smtpserver = smtplib.SMTP("smtp.gmail.com", 587)
 smtpserver.ehlo()
 smtpserver.starttls()
 smtpserver.ehlo()
@@ -26,5 +26,5 @@ for last_name, email in email_list.items():
     print("email for {} has been sent - {}".format(last_name, email))
     sleep(3)
 
-#用完记得disable
+# Remember to disable after running the script
 print("Finish! Make sure go to https://myaccount.google.com/u/1/lesssecureapps to disable less secure!")


### PR DESCRIPTION
At first I got some error about the Chinese comments in sendEmail.py. After removing those, I'm getting the error here:

C:\Git Workspace\EmailTool>python sendEmail.py
Traceback (most recent call last):
  File "sendEmail.py", line 7, in <module>
    message_body = file.read()
  File "C:\Users\sm045549\AppData\Local\Programs\Python\Python37-32\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 96: character maps to <undefined>

I figured that I had to replace all the double quotes with regular double quotes